### PR TITLE
qsearch

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -62,7 +62,7 @@ namespace Sigmoid {
                 return DRAW;
 
             if (depth == 0)
-                return board.eval(); // q_search(alpha, beta, stack);
+                return q_search(alpha, beta, stack);
 
             if (stack->ply >= MAX_PLY)
                 return board.eval();


### PR DESCRIPTION
Elo   | 549.46 +- 130.49 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 308 W: 292 L: 9 D: 7
Penta | [0, 1, 8, 6, 139]

bench 11710789