### PR TITLE
Alpha raise best move

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -197,7 +197,9 @@ namespace Sigmoid {
 
                 if (value > best_value) {
                     best_value = value;
-                    result.bestMove = move;
+
+                    if constexpr (root_node)
+                        result.bestMove = move;
 
                     if (value > alpha){
                         best_move = move;

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -197,9 +197,10 @@ namespace Sigmoid {
 
                 if (value > best_value) {
                     best_value = value;
+                    result.bestMove = move;
 
                     if (value > alpha){
-                        result.bestMove = best_move = move;
+                        best_move = move;
                         alpha = value;
                         flag = EXACT;
                     }

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -197,13 +197,9 @@ namespace Sigmoid {
 
                 if (value > best_value) {
                     best_value = value;
-                    best_move = move;
-
-                    if constexpr (root_node) {
-                        result.bestMove = move;
-                    }
 
                     if (value > alpha){
+                        result.bestMove = best_move = move;
                         alpha = value;
                         flag = EXACT;
                     }


### PR DESCRIPTION
Elo   | 14.53 +- 7.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4236 W: 1787 L: 1610 D: 839
Penta | [194, 268, 1062, 355, 239]

bench 671801