### PR TITLE
PvNode reduction tweak

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -209,6 +209,9 @@ namespace Sigmoid {
                 if (depth >= 3 && !root_node){
                     reduction = lmrTable[depth - 1][move_count - 1];
 
+                    if (pv_node)
+                        reduction -= 128;
+
                     reduction /= 128; // Scaling to a depth.
                     reduction = std::clamp((int)reduction, 0, depth - 2);
                 }


### PR DESCRIPTION
Elo   | 8.68 +- 5.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7688 W: 2706 L: 2514 D: 2468
Penta | [281, 765, 1614, 849, 335]


bench 28678156