### PR TITLE
Reduce quiets when tt move is a capture

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -215,7 +215,7 @@ namespace Sigmoid {
                         reduction -= 128;
 
                     if (!is_capture && tt_capture)
-                        reduction += 128;
+                        reduction += 64;
 
                     reduction /= 128; // Scaling to a depth.
                     reduction = std::clamp((int)reduction, 0, depth - 2);

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -125,6 +125,8 @@ namespace Sigmoid {
                 return board.eval();
 
             auto [entry, tt_hit] = tt->probe(board.key());
+            const bool tt_capture = tt_hit && board.is_capture(entry.move);
+
             if (!pv_node && tt_hit && entry.depth >= depth){
 
                 auto correct_tt_eval = [&stack](int16_t eval)-> int16_t {
@@ -211,6 +213,9 @@ namespace Sigmoid {
 
                     if (pv_node)
                         reduction -= 128;
+
+                    if (!is_capture && tt_capture)
+                        reduction += 128;
 
                     reduction /= 128; // Scaling to a depth.
                     reduction = std::clamp((int)reduction, 0, depth - 2);


### PR DESCRIPTION
Elo   | 6.78 +- 4.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10868 W: 3802 L: 3590 D: 3476
Penta | [416, 1147, 2168, 1215, 488]