### PR TITLE
Late move pruning

### DIFF
--- a/src/move.hpp
+++ b/src/move.hpp
@@ -59,6 +59,11 @@ namespace Sigmoid{
             return tmp < 3 ? Piece::NONE : Piece(tmp - 2);
         }
 
+        [[nodiscard]] bool is_promotion() const{
+            return promo_piece() != Piece::NONE;
+        }
+
+
         void set_data(int from, int to, SpecialType type = NONE){
             data = 0;
             data |= from;

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -202,6 +202,12 @@ namespace Sigmoid {
                     && static_eval + 110 * depth <= alpha && depth <= 8)
                     continue;
 
+                // Late move pruning.
+                const int move_count_limit = 3 + depth * depth;
+                if (!pv_node && !is_capture && !in_check
+                    && move_count > move_count_limit && !move.is_promotion())
+                    continue;
+
                 if (!board.make_move(move))
                     continue;
 


### PR DESCRIPTION
Elo   | 11.04 +- 6.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5790 W: 2040 L: 1856 D: 1894
Penta | [211, 578, 1184, 660, 262]

bench 16657239