### PR TITLE
Reduce more when not improving

### DIFF
--- a/src/search.hpp
+++ b/src/search.hpp
@@ -26,6 +26,7 @@ namespace Sigmoid {
         int8_t ply = 0;
         bool can_null = true;
         Piece movedPiece = NONE;
+        int16_t eval = MAX_VALUE;
     };
 }
 

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -51,8 +51,8 @@ namespace Sigmoid {
 
         void iterative_deepening() {
 
-            StackItem stack[MAX_PLY + 1];
-            StackItem* root = stack + 1;
+            StackItem stack[MAX_PLY + 5];
+            StackItem* root = stack + 5;
 
             for (int i = 0; i < MAX_PLY - 1; i++){
                 (root + i)->ply = i;
@@ -147,8 +147,10 @@ namespace Sigmoid {
                 return q_search(alpha, beta, stack);
 
             stack->can_null = (stack - 1)->can_null;
-            const int16_t static_eval = board.eval();
+            const int16_t static_eval = stack->eval = board.eval();
             const bool in_check = board.in_check();
+
+            const bool improving = stack->eval > (stack - 2)->eval;
 
             if (!in_check) {
                 // Reverse futility pruning.
@@ -223,6 +225,9 @@ namespace Sigmoid {
                         reduction -= 128;
 
                     if (!is_capture && tt_capture)
+                        reduction += 64;
+
+                    if (!improving)
                         reduction += 64;
 
                     reduction /= 128; // Scaling to a depth.


### PR DESCRIPTION
Elo   | 15.29 +- 8.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3842 W: 1331 L: 1162 D: 1349
Penta | [114, 415, 758, 456, 178]

Elo   | 8.13 +- 5.28 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7434 W: 2327 L: 2153 D: 2954
Penta | [179, 812, 1607, 894, 225]

bench 12563717