### PR TITLE
Double extension

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -239,7 +239,7 @@ namespace Sigmoid {
                     stack->excludedMove = Move::none();
 
                     if (value < singular_beta)
-                        extension = 1;
+                        extension = 1 + (!pv_node && value + 25 < singular_beta);
                 }
 
                 if (!board.make_move(move))


### PR DESCRIPTION
Elo   | 13.61 +- 7.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4420 W: 1518 L: 1345 D: 1557
Penta | [125, 468, 924, 495, 198]

Elo   | 25.08 +- 9.96 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1998 W: 674 L: 530 D: 794
Penta | [35, 190, 433, 278, 63]

bench 7127639