### PR TITLE
Negative extension

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -240,6 +240,9 @@ namespace Sigmoid {
 
                     if (value < singular_beta)
                         extension = 1 + (!pv_node && value + 25 < singular_beta);
+
+                    else if (entry.eval >= beta)
+                        extension = -1;
                 }
 
                 if (!board.make_move(move))


### PR DESCRIPTION
Elo   | 12.34 +- 7.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4984 W: 1723 L: 1546 D: 1715
Penta | [160, 529, 990, 600, 213]

Elo   | 22.72 +- 9.44 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2236 W: 747 L: 601 D: 888
Penta | [41, 220, 476, 314, 67]

bench 6746346