### PR TITLE
Improving lmp

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -211,7 +211,7 @@ namespace Sigmoid {
                         continue;
 
                     // Late move pruning.
-                    const int move_count_limit = 3 + depth * depth;
+                    const int move_count_limit = 3 + (depth * depth) / (2 - improving);
                     if (!pv_node && move_count > move_count_limit && !move.is_promotion())
                         continue;
 


### PR DESCRIPTION
Elo   | 10.68 +- 6.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5922 W: 2057 L: 1875 D: 1990
Penta | [197, 601, 1243, 663, 257]


Elo   | 10.95 +- 6.24 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4952 W: 1515 L: 1359 D: 2078
Penta | [105, 517, 1090, 645, 119]


bench 5995056