### PR TITLE
LMR - more reductions

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -461,7 +461,7 @@ namespace Sigmoid {
 
             for (int depth = 1; depth <= MAX_PLY; depth++)
                 for (int mc = 1; mc <= MAX_POSSIBLE_MOVES; mc++)
-                    lmrTable[depth - 1][mc - 1] = int16_t((0.5 + log(depth) * log(mc) * 0.3) * 128);
+                    lmrTable[depth - 1][mc - 1] = int16_t((0.75 + log(depth) * log(mc) * 0.35) * 128);
 
             loadedLmr = true;
         }


### PR DESCRIPTION
Elo   | 12.89 +- 7.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4532 W: 1554 L: 1386 D: 1592
Penta | [134, 468, 942, 540, 182]

Elo   | 7.44 +- 4.93 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8076 W: 2494 L: 2321 D: 3261
Penta | [158, 934, 1735, 999, 212]

bench 5510118