### PR TITLE
Bad captures ordering

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -369,8 +369,6 @@ namespace Sigmoid {
             return false;
         }
 
-        static constexpr int SEE_VALUES[6] = {100, 300, 300, 500, 900, 0};
-
         [[nodiscard]] bool see(const Sigmoid::Move &move, int threshold) const {
             const int from = move.from();
             const int to = move.to();

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -23,5 +23,7 @@ namespace Sigmoid {
     constexpr int16_t NUM_PIECES  = 6;
     constexpr int16_t NUM_COLORS  = 2;
 
+
+    static constexpr int SEE_VALUES[6] = {100, 300, 300, 500, 900, 0};
 }
 #endif //SIGMOID_CONSTANTS_HPP

--- a/src/movelist.hpp
+++ b/src/movelist.hpp
@@ -68,7 +68,12 @@ namespace Sigmoid {
                     Piece from_piece = board->at(move.from());
                     scores[i] = QUIET_OFFSET;
                     scores[i] += ((captured_piece + 1) * 100) * (KING - from_piece + 1);
-                    if (captureHistory){
+
+                    // Bad captures.
+                    if (!board->see(move, -SEE_VALUES[PAWN]))
+                        scores[i] = -1'000'000;
+
+                    else if (captureHistory){
                         Piece moved_piece = board->at(move.from());
                         int to_square = move.to();
 


### PR DESCRIPTION
Elo   | 17.19 +- 8.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3256 W: 1132 L: 971 D: 1153
Penta | [90, 310, 709, 387, 132]


Elo   | 17.47 +- 8.07 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2846 W: 913 L: 770 D: 1163
Penta | [48, 285, 636, 384, 70]

bench 4752325