### PR TITLE
Better TT entry replacement 

### DIFF
--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -43,7 +43,7 @@ namespace Sigmoid {
             const int index = get_index(key);
             Entry& entry = entries[index];
 
-            if (entry.key != key || depth > entry.depth)
+            if (entry.key != key || depth > entry.depth || flag == EXACT)
                 entry = {key, move, flag, depth, eval};
         }
 


### PR DESCRIPTION
Elo   | 15.34 +- 7.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3716 W: 1266 L: 1102 D: 1348
Penta | [99, 391, 778, 427, 163]


Elo   | 15.71 +- 7.54 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3098 W: 962 L: 822 D: 1314
Penta | [42, 325, 702, 411, 69]

bench 4654087
