### PR TITLE
Cutnode reduction

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -273,6 +273,9 @@ namespace Sigmoid {
                     if (!improving)
                         reduction += 64;
 
+                    if (cutNode)
+                        reduction += 128;
+
                     reduction /= 128; // Scaling to a depth.
                     reduction = std::clamp((int)reduction, 0, new_depth - 2);
 


### PR DESCRIPTION
Elo   | 5.11 +- 3.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15834 W: 5382 L: 5149 D: 5303
Penta | [576, 1675, 3239, 1794, 633]

Elo   | 8.48 +- 5.38 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6886 W: 2129 L: 1961 D: 2796
Penta | [159, 733, 1517, 849, 185]

bench 6021952