### PR TITLE
Remove depth addition in the NMP condition

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -167,7 +167,7 @@ namespace Sigmoid {
                 // Null move pruning.
                 const bool some_piece = board.some_big_piece();
                 if (!pv_node && depth >= 3 && stack->can_null && some_piece
-                    && static_eval >= beta + 50 * depth){
+                    && static_eval >= beta){
 
                     int16_t reduction = 3 + depth / 3;
                     int16_t nmp_depth = std::max(depth - reduction, 1);


### PR DESCRIPTION
Elo   | 36.99 +- 12.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1452 W: 562 L: 408 D: 482
Penta | [31, 124, 310, 182, 79]


Elo   | 49.02 +- 14.30 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1056 W: 395 L: 247 D: 414
Penta | [15, 84, 217, 162, 50]


bench 4837863