### PR TITLE
TT probe fix

### DIFF
--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -51,9 +51,13 @@ namespace Sigmoid {
             __builtin_prefetch(&entries[get_index(key)]);
         }
 
-        std::pair<const Entry&, bool> probe(uint64_t key){
+        std::pair<Entry, bool> probe(uint64_t key){
             const int index = get_index(key);
-            return {entries[index], entries[index].key == key};
+            Entry entry = entries[index];
+
+            const bool tt_hit = entries[index].key == key;
+            entry.move = tt_hit ? entry.move : Move::none();
+            return {entry, tt_hit};
         }
 
         inline int get_index(const uint64_t& key){


### PR DESCRIPTION
Elo   | 17.02 +- 8.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3432 W: 1197 L: 1029 D: 1206
Penta | [117, 318, 708, 426, 147]

Elo   | 9.66 +- 5.71 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5396 W: 1714 L: 1564 D: 2118
Penta | [86, 571, 1268, 653, 120]


Elo   | 9.77 +- 6.05 (95%)
SPRT  | 6.0+0.06s Threads=2 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6366 W: 2141 L: 1962 D: 2263
Penta | [206, 659, 1302, 782, 234]

bench 4749596