### PR TITLE
More next for cutnodes

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -252,7 +252,7 @@ namespace Sigmoid {
                     else if (entry.eval >= beta)
                         extension = -1;
                     else if (cutNode)
-                        extension = -1;
+                        extension = -2;
                 }
 
                 if (!board.make_move(move))


### PR DESCRIPTION
Elo   | 3.72 +- 2.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 25250 W: 8244 L: 7974 D: 9032
Penta | [766, 2845, 5240, 2901, 873]

Elo   | 3.11 +- 2.50 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29006 W: 8682 L: 8422 D: 11902
Penta | [546, 3326, 6536, 3512, 583]


bench 5024710