### PR TITLE
Move history reductions

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -242,7 +242,6 @@ namespace Sigmoid {
                 if (!root_node && depth <= 7 && is_capture && !in_check && !board.see(move, -40 * depth * depth))
                     continue;
 
-
                 // Singular extensions.
                 int extension = 0;
                 if (!root_node && move == entry.move &&
@@ -265,6 +264,16 @@ namespace Sigmoid {
                         extension = -2;
                 }
 
+                int move_score = 0;
+                if (is_capture){
+                    int to_square = move.to();
+                    Piece captured_piece = move.special_type() == Move::EN_PASSANT ? PAWN : board.at(move.to());
+                    move_score = captureHistory[stack->movedPiece][to_square][captured_piece];
+                }
+                else{
+                    move_score = mainHistory[board.whoPlay][move.from()][move.to()];
+                }
+
                 if (!board.make_move(move))
                     continue;
 
@@ -277,6 +286,7 @@ namespace Sigmoid {
 
                 const int new_depth = depth - 1 + extension;
                 if (depth >= 3 && !root_node && move_count > 3){
+
                     reduction = lmrTable[depth - 1][move_count - 1];
                     if (pv_node)
                         reduction -= 128;
@@ -289,6 +299,8 @@ namespace Sigmoid {
 
                     if (cutNode)
                         reduction += 128;
+
+                    reduction -= move_score / 256;
 
                     reduction /= 128; // Scaling to a depth.
                     reduction = std::clamp((int)reduction, 0, new_depth - 2);


### PR DESCRIPTION

Elo   | 10.80 +- 6.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5630 W: 1861 L: 1686 D: 2083
Penta | [164, 605, 1144, 696, 206]

Elo   | 9.46 +- 5.22 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.50, 5.00]
Games | N: 5988 W: 1798 L: 1635 D: 2555
Penta | [63, 671, 1414, 732, 114]


bench 4444989