### PR TITLE
32b TT key

### DIFF
--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -14,7 +14,7 @@ namespace Sigmoid {
     };
 
     struct Entry {
-        uint64_t key;
+        uint32_t key = 0;
         Move move = Move::none();
         TTFlag flag;
         int8_t depth = 0;
@@ -37,14 +37,20 @@ namespace Sigmoid {
             std::fill(entries, entries + numberOfEntries, Entry{});
         }
 
+        inline uint32_t entry_key(uint64_t key){
+            return uint32_t(key >> 32);
+        }
+
         void store(uint64_t key, const Move& move, TTFlag flag, int8_t depth, int16_t eval, int16_t ply){
             if (eval >= CHECKMATE_BOUND) eval += ply;
             else if (eval <= -CHECKMATE_BOUND) eval -= ply;
             const int index = get_index(key);
             Entry& entry = entries[index];
 
-            if (entry.key != key || depth > entry.depth || flag == EXACT)
-                entry = {key, move, flag, depth, eval};
+            uint32_t e_key = entry_key(key);
+
+            if (entry.key != e_key || depth > entry.depth || flag == EXACT)
+                entry = {e_key, move, flag, depth, eval};
         }
 
         void prefetch(uint64_t key){
@@ -55,7 +61,7 @@ namespace Sigmoid {
             const int index = get_index(key);
             Entry entry = entries[index];
 
-            const bool tt_hit = entries[index].key == key;
+            const bool tt_hit = entries[index].key == entry_key(key);
             entry.move = tt_hit ? entry.move : Move::none();
             return {entry, tt_hit};
         }


### PR DESCRIPTION
Elo   | 28.26 +- 10.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1836 W: 658 L: 509 D: 669
Penta | [36, 175, 382, 254, 71]

Elo   | 23.88 +- 8.82 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.50, 5.00]
Games | N: 2186 W: 702 L: 552 D: 932
Penta | [25, 216, 475, 338, 39]

bench 4784697