### PR TITLE
Reduce less when check

### DIFF
--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -309,6 +309,9 @@ namespace Sigmoid {
                     if (cutNode)
                         reduction += 128;
 
+                    if (board.in_check())
+                        reduction -= 128;
+
                     reduction -= move_score / 256;
 
                     reduction /= 128; // Scaling to a depth.


### PR DESCRIPTION
Elo   | 10.34 +- 6.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5476 W: 1754 L: 1591 D: 2131
Penta | [114, 613, 1187, 644, 180]

Elo   | 8.89 +- 5.39 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5826 W: 1741 L: 1592 D: 2493
Penta | [80, 640, 1353, 731, 109]

bench 3945634