### PR TITLE
2 ply continuation history

### DIFF
--- a/src/history.hpp
+++ b/src/history.hpp
@@ -37,8 +37,14 @@ namespace Sigmoid{
     using CaptureHistory = History<MAX_CAP_HIST_BONUS, NUM_PIECES, NUM_SQUARES, NUM_PIECES>;
 
     using MainHistory = History<std::numeric_limits<int16_t>::max(), NUM_COLORS, NUM_SQUARES, NUM_SQUARES>;
-    const int CONT_HIST_MAX_PLY = 1;
+
+    const int CONT_HIST_MAX_PLY = 2;
     const int MAX_CONT_HIST_BONUS = 20'000;
+
+    const int CONT_PLY_BONUS_SCALE_BASE = 128;
+    const std::array<int, 3> CONT_PLY_IDX_SCALES[2] = {{1, 0, 128}, {2, 1, 128}};
+    const std::array<int, 2> CONT_PLY_IDX[2] = {{1, 0}, {2, 1}};
+
     // [prev_pc][prev_to_sq] [pc][to_sq]
     using ContinuationHistoryEntry = History<MAX_CONT_HIST_BONUS, NUM_PIECES, NUM_SQUARES, NUM_PIECES, NUM_SQUARES>;
     using ContinuationHistory = std::array<ContinuationHistoryEntry::type, CONT_HIST_MAX_PLY>;

--- a/src/movelist.hpp
+++ b/src/movelist.hpp
@@ -94,15 +94,15 @@ namespace Sigmoid {
 
                         auto get_cont_ply_hist = [&]() -> int {
                             int cont_ply_hist_score = 0;
-                            for (int n_ply = 1; n_ply <= CONT_HIST_MAX_PLY; n_ply++) {
-                                const Move &previous_move = (stack - n_ply)->currentMove;
-                                const Piece previous_moved_piece = (stack - n_ply)->movedPiece;
+                            for (const auto [ply, idx] : CONT_PLY_IDX){
+                                const Move &previous_move = (stack - ply)->currentMove;
+                                const Piece previous_moved_piece = (stack - ply)->movedPiece;
                                 if (previous_move == Move::none() || previous_move == Move::null())
                                     break;
 
                                 const Piece current_piece = board->at(move.from());
                                 int16_t entry =
-                                        (*continuationHistory)[n_ply -1][previous_moved_piece][previous_move.to()][current_piece][move.to()];
+                                        (*continuationHistory)[idx][previous_moved_piece][previous_move.to()][current_piece][move.to()];
                                 cont_ply_hist_score += entry;
                             }
                             return cont_ply_hist_score;

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -469,14 +469,15 @@ namespace Sigmoid {
         void update_continuation_histories_move(const StackItem* stack, const Move& move, int bonus, const Piece movedPiece){
             assert(movedPiece != NONE);
 
-            for (int n_ply = 1; n_ply <= CONT_HIST_MAX_PLY; n_ply++){
-                const Move& previous_move = (stack - n_ply)->currentMove;
-                const Piece previous_piece = (stack - n_ply)->movedPiece;
+            for (const auto [ply, idx, scale] : CONT_PLY_IDX_SCALES){
+                const Move& previous_move = (stack - ply)->currentMove;
+                const Piece previous_piece = (stack - ply)->movedPiece;
                 if (previous_move == Move::none() || previous_move == Move::null())
                     break;
 
-                int& entry = continuationHistory[n_ply - 1][previous_piece][previous_move.to()][movedPiece][move.to()];
-                apply_gravity(entry, bonus, ContinuationHistoryEntry::maxValue);
+                const int scaled_bonus = (bonus * scale) / CONT_PLY_BONUS_SCALE_BASE;
+                int& entry = continuationHistory[idx][previous_piece][previous_move.to()][movedPiece][move.to()];
+                apply_gravity(entry, scaled_bonus, ContinuationHistoryEntry::maxValue);
             }
         }
 


### PR DESCRIPTION
Elo   | 8.50 +- 5.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7034 W: 2308 L: 2136 D: 2590
Penta | [171, 744, 1563, 820, 219]

Elo   | 7.38 +- 4.42 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.50, 5.00]
Games | N: 7866 W: 2237 L: 2070 D: 3559
Penta | [90, 844, 1914, 979, 106]

bench 3857971